### PR TITLE
Fix broken monospace font size in Chrome

### DIFF
--- a/_sass/no-style-please.scss
+++ b/_sass/no-style-please.scss
@@ -23,9 +23,12 @@ html, body { background-color: white; }
 
 html { height: 100%; }
 
+// Handling monospace font size in browsers is fundamentally broken.  A hacky solution is applied to
+// prevent browsers from reducing the monospace font size arbitrarily.
+// see: http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/
 body {
   color: black;
-  font-family: monospace;
+  font-family: monospace, monospace;
   font-size: 1.3rem;
   line-height: 1.3;
   margin: 0;


### PR DESCRIPTION
This commit fixes the broken monospace font size in Chrome.  As written below, the size of
`monospace` font in css is reduced, usually about 3px, arbitrarily by browsers.

> Major web browsers automatically reduce the size of monospace text in a range of situations. They
> do this due to the greater width of many monospace typefaces in comparison to other fonts at the
> same text height. While well-intentioned, their handling of monospace fonts is fundamentally
> broken, and an unusual CSS rule is required to fix the problem.

http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/

To avoid the issue, this commit applies a hack suggested in the page: `font-family: monospace,
monospace`.

Note that this change does NOT affect its font size in Firefox.